### PR TITLE
sticky class added

### DIFF
--- a/static/mainapp/css/layout.css
+++ b/static/mainapp/css/layout.css
@@ -5,7 +5,12 @@ body {
   max-width: 100%;
   overflow-x: hidden;
 }
-
+.sticky{
+  position: sticky;
+  top: 0px;
+  padding: 5px;  
+  border: 2px solid #4caf50;
+}
 #navbarNav {
   float: right;
 }

--- a/templates/mainapp/layout.html
+++ b/templates/mainapp/layout.html
@@ -38,7 +38,7 @@
 
     <header>
         <div id="topheader">
-            <nav class="navbar navbar-expand-md navbar-light">
+            <nav class="navbar navbar-expand-md navbar-light sticky">
                 <a class="navbar-brand head-text" href="/">Kitabe</a>
                 <!-- Search Bar -->
                 <div class="searchbar" id="searchdropdown">


### PR DESCRIPTION
## Description
- List out your changes
- Link the Issue which this resolves
## problem : The navbar disappears as soon as we scroll down.

## solution: You have to make (Navbar)position :sticky so that navbar stick on top
So, i just added a class in layout.html
and define the property of sticky class in layout.css 

![sticky](https://user-images.githubusercontent.com/33158343/110582076-a09fcb80-8191-11eb-8f1e-086fd39bd506.png)

In above picture you can check Navbar is fix , while scrolling the page.




