### PR TITLE
Changed layout of explore page

### DIFF
--- a/BookRecSystem/settings.py
+++ b/BookRecSystem/settings.py
@@ -22,12 +22,12 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ.get('KITABE_SECRET_KEY')
+SECRET_KEY = "RANDOM_KEY"
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['kitabe-app.herokuapp.com']
+ALLOWED_HOSTS = ['kitabe-app.herokuapp.com', '127.0.0.1', 'localhost']
 
 
 # Application definition

--- a/BookRecSystem/settings.py
+++ b/BookRecSystem/settings.py
@@ -22,12 +22,12 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "RANDOM_KEY"
+SECRET_KEY = os.environ.get('KITABE_SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['kitabe-app.herokuapp.com', '127.0.0.1', 'localhost']
+ALLOWED_HOSTS = ['kitabe-app.herokuapp.com']
 
 
 # Application definition

--- a/static/mainapp/css/explore.css
+++ b/static/mainapp/css/explore.css
@@ -201,7 +201,7 @@
   .small-screen {
     display: inline;
   }
-  .card-deck {
+  .card{
     margin: auto;
   }
   .cover-img-size{

--- a/static/mainapp/css/explore.css
+++ b/static/mainapp/css/explore.css
@@ -140,7 +140,7 @@
   border-radius: 20px;
   position: absolute;
   bottom: 10px;
-  right: 8.5%;
+  right: 2%;
 }
 
 .more-details:hover {

--- a/static/mainapp/css/explore.css
+++ b/static/mainapp/css/explore.css
@@ -140,7 +140,7 @@
   border-radius: 20px;
   position: absolute;
   bottom: 10px;
-  right: 10%;
+  right: 8.5%;
 }
 
 .more-details:hover {
@@ -190,10 +190,10 @@
     display: block;
   }
   .rating-block {
-    margin-left: 7%;
+    margin-left: 5%;
   }
   .more-details {
-    margin-left: 9%;
+    right: 15%;
   }
   .large-screen {
     display: none;
@@ -201,7 +201,14 @@
   .small-screen {
     display: inline;
   }
-  .card {
+  .card-deck {
     margin: auto;
+  }
+  .cover-img-size{
+    margin: auto;
+    margin-top: 8%;
+  }
+  .row{
+    margin-bottom: 5%;
   }
 }

--- a/static/mainapp/css/explore.css
+++ b/static/mainapp/css/explore.css
@@ -48,33 +48,6 @@
   padding-bottom: 1%;
 }
 
-.more-details {
-  text-align: center;
-  background-color: #3d348b;
-  color: #fff;
-  font-weight: 600;
-  font-size: 12px;
-  border-radius: 20px;
-}
-
-.rating-block {
-  text-align: center;
-  background-color: #31c2cf;
-  font-weight: 600;
-  font-size: 12px;
-  border-radius: 20px;
-  padding: 5px;
-}
-
-.rating-block:hover {
-  text-shadow: 0px 0px 6px rgba(255, 255, 255, 1);
-  transition: all 0.4s ease 0s;
-}
-.more-details:hover {
-  color: white;
-  text-shadow: 0px 0px 6px rgba(255, 255, 255, 1);
-  transition: all 0.4s ease 0s;
-}
 
 .rateYo {
   margin-left: auto;
@@ -84,6 +57,126 @@
 
 .small-screen {
   display: none;
+}
+
+.card-deck {
+  padding-left: 5%;
+  padding-right: 5%;
+  padding-bottom: 2%;
+}
+
+.card {
+  transition: 0.5s;
+  cursor: pointer;
+  border-radius: 3px;
+  box-shadow: -2px 6px 19px 0px #7f818e;
+}
+
+.card-img {
+  flex-shrink: 0;
+  bottom: -35px;
+  left: 35px;
+  border-radius: 3px;
+  box-shadow: -2px 6px 19px 0px #7f818e;
+  transition: 0.3s ease;
+  width: 85%;
+  height: 60%;
+  margin: 0 auto;
+}
+
+.card-img:hover {
+  transform: scale(1.07);
+}
+
+.card-horizontal {
+  display: flex;
+  flex: 1 1 auto;
+}
+
+.card-body-wrap {
+  display: flex;
+}
+
+.card-title {
+  font-family: "Sora", sans-serif;
+  font-size: large;
+  color: #d7722c;
+}
+
+.card::before,
+.card::after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  transform: scale3d(0, 0, 1);
+  transition: transform 0.3s ease-out 0s;
+  content: "";
+  pointer-events: none;
+}
+
+.card::before {
+  transform-origin: left top;
+}
+
+.card::after {
+  transform-origin: right bottom;
+}
+
+.card:hover::before,
+.card:hover::after,
+.card:focus::before,
+.card:focus::after {
+  transform: scale3d(1, 1, 1);
+}
+
+.more-details {
+  text-align: center;
+  background-color: #3d348b;
+  color: #fff;
+  font-weight: 600;
+  font-size: 11px;
+  border-radius: 20px;
+  position: absolute;
+  bottom: 10px;
+  right: 10%;
+}
+
+.more-details:hover {
+  color: white;
+}
+
+.rating-block {
+  display: inline-block;
+  text-align: center;
+  background-color: #31c2cf;
+  font-weight: 600;
+  font-size: 11px;
+  border-radius: 20px;
+  position: absolute;
+  padding: 8px;
+  bottom: 10px;
+  left: 10%;
+}
+
+.rating-block:hover {
+  text-shadow: 0px 0px 6px rgba(255, 255, 255, 1);
+  transition: all 0.4s ease 0s;
+}
+
+.card-text {
+  font-family: "Courgette", cursive;
+  color: black;
+  font-weight: bold;
+  font-size: 15px;
+  padding-bottom: 1px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  /* number of lines to show */
+  -webkit-box-orient: vertical;
 }
 
 @media (max-width: 420px) {
@@ -107,5 +200,8 @@
   }
   .small-screen {
     display: inline;
+  }
+  .card {
+    margin: auto;
   }
 }

--- a/static/mainapp/css/explore.css
+++ b/static/mainapp/css/explore.css
@@ -157,7 +157,7 @@
   position: absolute;
   padding: 8px;
   bottom: 10px;
-  left: 10%;
+  left: 7%;
 }
 
 .rating-block:hover {
@@ -201,7 +201,7 @@
   .small-screen {
     display: inline;
   }
-  .card{
+  .card, .card-deck{ 
     margin: auto;
   }
   .cover-img-size{
@@ -210,5 +210,17 @@
   }
   .row{
     margin-bottom: 5%;
+  }
+}
+
+@media (max-width: 370px){
+  .card, .card-deck{ 
+    margin-left: -1%;
+  }
+}
+
+@media (max-width: 390px){
+  .card, .card-deck{ 
+    margin-left: -0.5%;
   }
 }

--- a/static/mainapp/css/explore.css
+++ b/static/mainapp/css/explore.css
@@ -213,14 +213,8 @@
   }
 }
 
-@media (max-width: 370px){
-  .card, .card-deck{ 
-    margin-left: -1%;
-  }
-}
-
 @media (max-width: 390px){
   .card, .card-deck{ 
-    margin-left: -0.5%;
+    margin-left: -1.5%;
   }
 }

--- a/templates/mainapp/explore.html
+++ b/templates/mainapp/explore.html
@@ -107,107 +107,104 @@ Explore
 
 
     <div id="demo2" class="carousel slide" data-ride="carousel">
-        <!------------------------------------- carousel second row -------------------------->
+        <!------------------------------------- carousel first row -------------------------->
         <div class=" carousel-inner " class="ml-auto">
-            <div class="carousel-item active">
-                {% for book in book|slice:"50:100" %}
-                <div class="wrapper" style="display:inline-flex;">
-                    <div class="single-card">
-                        <div class="data">
-                            <div class="cover-img">
-                                <img class=" cover-img-size" src="{{book.image_url}}" alt="book Card">
+            <div class="card-deck">
+                <div class="carousel-item active">
+                    {% for book in book|slice:"50:100" %}
+                    <div class="card col-sm-12 col-lg-3 " style="width: 300px;">
+                        <div class="row no-gutters">
+                            <br>
+                            <img class=" cover-img-size" src="{{book.image_url}}" alt="book Card">
+                            
+                            <div class="card-body text-center">
+                                <div class="card-title">{{ book.original_title }}</div>
+                                <div class="card-text">by {{ book.authors}}</div>
                             </div>
-                            <div class="content text-center">
-                                <div class="title">{{ book.original_title }}</div>
-                                <div class="author">by {{ book.authors}}</div>
+                        </div><br>
+                        <a href="javascript:;" onclick='bookDetails(this)' class="btn more-details"
+                            data-book-id="{{ book.book_id }}">More Details</a>
+                        {% if user.is_authenticated %}
+                        <div class='rating-block' id='rating-block-{{ book.book_id }}' onmouseover="rateStart(this)"
+                            onclick='rateBook(this)' onmouseout='finishRate(this)'
+                            data-book-id="{{ book.book_id }}">
+                            <div id='button-text-{{ book.book_id }}'>Rate <i class="fa fa-heart"
+                                    style="color:red"></i> This Book
+                                </a>
+                            </div>
+                            <div class='rateYo' id='rate-{{ book.book_id }}'></div>
+                        </div>
+                        {% else %}
+                        <div class='rating-block btn' onclick="location.href='{% url 'account_signup' %}'">
+                            <div id='button-text'>Rate <i class="fa fa-heart" style="color:red"></i> This Book</a>
                             </div>
                         </div>
-                        <div class="hide text-center">
-                            <a href="javascript:;" onclick='bookDetails(this)' class="btn more-details"
-                                data-book-id="{{ book.book_id }}">More Details</a>
-                            {% if user.is_authenticated %}
-                            <div class='rating-block' id='rating-block-{{ book.book_id }}' onmouseover="rateStart(this)"
-                                onclick='rateBook(this)' onmouseout='finishRate(this)'
-                                data-book-id="{{ book.book_id }}">
-                                <div id='button-text-{{ book.book_id }}'>Rate <i class="fa fa-heart"
-                                        style="color:red"></i> This Book
-                                    </a>
-                                </div>
-                                <div class='rateYo' id='rate-{{ book.book_id }}'></div>
-                            </div>
-                            {% else %}
-                            <div class='rating-block btn' onclick="location.href='{% url 'account_signup' %}'">
-                                <div id='button-text'>Rate <i class="fa fa-heart" style="color:red"></i> This Book</a>
-                                </div>
-                            </div>
-                            {% endif %}
-                        </div>
+                        {% endif %}
                     </div>
+                    {% if forloop.counter|divisibleby:5 and forloop.counter > 0 and not forloop.last %}
                 </div>
-                {% if forloop.counter|divisibleby:5 and forloop.counter > 0 and not forloop.last %}
-            </div>
-            <div class="carousel-item ">
-                {% endif %} {% endfor %}
+                <div class="carousel-item">
+                    {% endif %} {% endfor %}
+                </div>
             </div>
         </div>
-        <a class="carousel-control-prev top-books-carousel" href="#demo2" role="button" data-slide="prev">
+        <a class="carousel-control-prev top-books-carousel" href="#demo" role="button" data-slide="prev">
             <span class="carousel-control-prev-icon " aria-hidden="true"></span>
             <span class="sr-only">Previous</span>
         </a>
-        <a class="carousel-control-next top-books-carousel" href="#demo2" role="button" data-slide="next">
+        <a class="carousel-control-next top-books-carousel" href="#demo" role="button" data-slide="next">
             <span class="carousel-control-next-icon " aria-hidden="true"></span>
             <span class="sr-only">Next</span>
         </a>
     </div>
 
     <div id="demo3" class="carousel slide" data-ride="carousel">
-        <!------------------------------------- carousel third row -------------------------->
+        <!------------------------------------- carousel first row -------------------------->
         <div class=" carousel-inner " class="ml-auto">
-            <div class="carousel-item active">
-                {% for book in book|slice:"100:150" %}
-                <div class="wrapper" style="display:inline-flex;">
-                    <div class="single-book">
-                        <div class="data">
-                            <div class="cover-img">
-                                <img class=" cover-img-size" src="{{book.image_url}}" alt="book Card">
+            <div class="card-deck">
+                <div class="carousel-item active">
+                    {% for book in book|slice:"100:150" %}
+                    <div class="card col-sm-12 col-lg-3 " style="width: 300px;">
+                        <div class="row no-gutters">
+                            <br>
+                            <img class=" cover-img-size" src="{{book.image_url}}" alt="book Card">
+                            
+                            <div class="card-body text-center">
+                                <div class="card-title">{{ book.original_title }}</div>
+                                <div class="card-text">by {{ book.authors}}</div>
                             </div>
-                            <div class="content text-center">
-                                <div class="title">{{ book.original_title }}</div>
-                                <div class="author">by {{ book.authors}}</div>
+                        </div><br>
+                        <a href="javascript:;" onclick='bookDetails(this)' class="btn more-details"
+                            data-book-id="{{ book.book_id }}">More Details</a>
+                        {% if user.is_authenticated %}
+                        <div class='rating-block' id='rating-block-{{ book.book_id }}' onmouseover="rateStart(this)"
+                            onclick='rateBook(this)' onmouseout='finishRate(this)'
+                            data-book-id="{{ book.book_id }}">
+                            <div id='button-text-{{ book.book_id }}'>Rate <i class="fa fa-heart"
+                                    style="color:red"></i> This Book
+                                </a>
+                            </div>
+                            <div class='rateYo' id='rate-{{ book.book_id }}'></div>
+                        </div>
+                        {% else %}
+                        <div class='rating-block btn' onclick="location.href='{% url 'account_signup' %}'">
+                            <div id='button-text'>Rate <i class="fa fa-heart" style="color:red"></i> This Book</a>
                             </div>
                         </div>
-                        <div class="hide text-center">
-                            <a href="javascript:;" onclick='bookDetails(this)' class="btn more-details"
-                                data-book-id="{{ book.book_id }}">More Details</a>
-                            {% if user.is_authenticated %}
-                            <div class='rating-block' onmouseover="rateStart(this)" onclick='rateBook(this)'
-                                onmouseout='finishRate(this)' data-book-id="{{ book.book_id }}">
-                                <div id='button-text-{{ book.book_id }}'>Rate <i class="fa fa-heart"
-                                        style="color:red"></i> This Book
-                                    </a>
-                                </div>
-                                <div class='rateYo' id='rate-{{ book.book_id }}'></div>
-                            </div>
-                            {% else %}
-                            <div class='rating-block btn' onclick="location.href='{% url 'account_signup' %}'">
-                                <div id='button-text'>Rate <i class="fa fa-heart" style="color:red"></i> This Book</a>
-                                </div>
-                            </div>
-                            {% endif %}
-                        </div>
+                        {% endif %}
                     </div>
+                    {% if forloop.counter|divisibleby:5 and forloop.counter > 0 and not forloop.last %}
                 </div>
-                {% if forloop.counter|divisibleby:5 and forloop.counter > 0 and not forloop.last %}
-            </div>
-            <div class="carousel-item ">
-                {% endif %} {% endfor %}
+                <div class="carousel-item">
+                    {% endif %} {% endfor %}
+                </div>
             </div>
         </div>
-        <a class="carousel-control-prev top-books-carousel" href="#demo3" role="button" data-slide="prev">
+        <a class="carousel-control-prev top-books-carousel" href="#demo" role="button" data-slide="prev">
             <span class="carousel-control-prev-icon " aria-hidden="true"></span>
             <span class="sr-only">Previous</span>
         </a>
-        <a class="carousel-control-next top-books-carousel" href="#demo3" role="button" data-slide="next">
+        <a class="carousel-control-next top-books-carousel" href="#demo" role="button" data-slide="next">
             <span class="carousel-control-next-icon " aria-hidden="true"></span>
             <span class="sr-only">Next</span>
         </a>

--- a/templates/mainapp/explore.html
+++ b/templates/mainapp/explore.html
@@ -61,6 +61,7 @@ Explore
                     {% for book in book|slice:":50"%}
                     <div class="card col-sm-12 col-lg-3 " style="width: 300px;">
                         <div class="row no-gutters">
+                            <br>
                             <img class=" cover-img-size" src="{{book.image_url}}" alt="book Card">
                             
                             <div class="card-body text-center">

--- a/templates/mainapp/explore.html
+++ b/templates/mainapp/explore.html
@@ -14,40 +14,39 @@ Explore
 {% block main %}
 
 <div class="large-screen" style="width:1200px; margin:0 auto;">
-    <div class="centre">
+    <div class="centre, card-deck">
         {% for book in book %}
-        <div class="wrapper" style="display:inline-flex;">
-            <div>
-                <div class="data">
-                    <div class="cover-img">
-                        <img class=" cover-img-size" src="{{book.image_url}}" alt="book Card">
-                    </div>
-                    <div class="content text-center">
-                        <div class="title">{{ book.original_title }}</div>
-                        <div class="author">by {{ book.authors}}</div>
-                    </div>
+        <div class="card col-sm-12 col-lg-3 " style="width: 300px;">
+            <div class="row no-gutters">
+                <img class=" card-img  mt-4 " src="{{book.image_url}}" alt="book Card">
+                
+                <div class="content text-center">
+                    <div class="card-title">{{ book.original_title }}</div>
+                    <div class="card-text">by {{ book.authors}}</div>
                 </div>
-                <div class="hide text-center">
-                    <a href="javascript:;" onclick='bookDetails(this)' class="btn more-details"
-                        data-book-id="{{ book.book_id }}">More Details</a>
-                    {% if user.is_authenticated %}
-                    <div class='rating-block' id='rating-block-{{ book.book_id }}' onmouseover="rateStart(this)"
-                        onclick='rateBook(this)' onmouseout='finishRate(this)' data-book-id="{{ book.book_id }}">
-                        <div id='button-text-{{ book.book_id }}'>Rate <i class="fa fa-heart" style="color:red"></i> This
-                            Book
-                            </a>
-                        </div>
-                        <div class='rateYo' id='rate-{{ book.book_id }}'></div>
-                    </div>
-                    {% else %}
-                    <div class='rating-block btn' onclick="location.href='{% url 'account_signup' %}'">
-                        <div id='button-text'>Rate <i class="fa fa-heart" style="color:red"></i> This Book</a>
-                        </div>
-                    </div>
-                    {% endif %}
+            </div><br>
+            <a href="javascript:;" onclick='bookDetails(this)' class="btn more-details"
+                data-book-id="{{ book.book_id }}">More Details</a>
+            {% if user.is_authenticated %}
+            <div class='rating-block' id='rating-block-{{ book.book_id }}' onmouseover="rateStart(this)"
+                onclick='rateBook(this)' onmouseout='finishRate(this)' data-book-id="{{ book.book_id }}">
+                <div id='button-text-{{ book.book_id }}'>Rate <i class="fa fa-heart" style="color:red"></i> This
+                    Book
+                    </a>
+                </div>
+                <div class='rateYo' id='rate-{{ book.book_id }}'></div>
+            </div>
+            {% else %}
+            <div class='rating-block btn' onclick="location.href='{% url 'account_signup' %}'">
+                <div id='button-text'>Rate <i class="fa fa-heart" style="color:red"></i> This Book</a>
                 </div>
             </div>
+            {% endif %}
         </div>
+        {% if forloop.counter|divisibleby:"4"  %}
+    </div>
+    <div class="card-deck  ">
+        {% endif %}
         {% endfor %}
     </div>
 </div>
@@ -57,45 +56,42 @@ Explore
     <div id="demo" class="carousel slide" data-ride="carousel">
         <!------------------------------------- carousel first row -------------------------->
         <div class=" carousel-inner " class="ml-auto">
-            <div class="carousel-item active">
-                {% for book in book|slice:":50"%}
-                <div class="wrapper" style="display:inline-flex;">
-                    <div>
-                        <div class="data">
-                            <div class="cover-img">
-                                <img class=" cover-img-size" src="{{book.image_url}}" alt="book Card">
+            <div class="card-deck">
+                <div class="carousel-item active">
+                    {% for book in book|slice:":50"%}
+                    <div class="card col-sm-12 col-lg-3 " style="width: 300px;">
+                        <div class="row no-gutters">
+                            <img class=" cover-img-size" src="{{book.image_url}}" alt="book Card">
+                            
+                            <div class="card-body text-center">
+                                <div class="card-title">{{ book.original_title }}</div>
+                                <div class="card-text">by {{ book.authors}}</div>
                             </div>
-                            <div class="content text-center">
-                                <div class="title">{{ book.original_title }}</div>
-                                <div class="author">by {{ book.authors}}</div>
+                        </div><br>
+                        <a href="javascript:;" onclick='bookDetails(this)' class="btn more-details"
+                            data-book-id="{{ book.book_id }}">More Details</a>
+                        {% if user.is_authenticated %}
+                        <div class='rating-block' id='rating-block-{{ book.book_id }}' onmouseover="rateStart(this)"
+                            onclick='rateBook(this)' onmouseout='finishRate(this)'
+                            data-book-id="{{ book.book_id }}">
+                            <div id='button-text-{{ book.book_id }}'>Rate <i class="fa fa-heart"
+                                    style="color:red"></i> This Book
+                                </a>
+                            </div>
+                            <div class='rateYo' id='rate-{{ book.book_id }}'></div>
+                        </div>
+                        {% else %}
+                        <div class='rating-block btn' onclick="location.href='{% url 'account_signup' %}'">
+                            <div id='button-text'>Rate <i class="fa fa-heart" style="color:red"></i> This Book</a>
                             </div>
                         </div>
-                        <div class="hide text-center">
-                            <a href="javascript:;" onclick='bookDetails(this)' class="btn more-details"
-                                data-book-id="{{ book.book_id }}">More Details</a>
-                            {% if user.is_authenticated %}
-                            <div class='rating-block' id='rating-block-{{ book.book_id }}' onmouseover="rateStart(this)"
-                                onclick='rateBook(this)' onmouseout='finishRate(this)'
-                                data-book-id="{{ book.book_id }}">
-                                <div id='button-text-{{ book.book_id }}'>Rate <i class="fa fa-heart"
-                                        style="color:red"></i> This Book
-                                    </a>
-                                </div>
-                                <div class='rateYo' id='rate-{{ book.book_id }}'></div>
-                            </div>
-                            {% else %}
-                            <div class='rating-block btn' onclick="location.href='{% url 'account_signup' %}'">
-                                <div id='button-text'>Rate <i class="fa fa-heart" style="color:red"></i> This Book</a>
-                                </div>
-                            </div>
-                            {% endif %}
-                        </div>
+                        {% endif %}
                     </div>
+                    {% if forloop.counter|divisibleby:5 and forloop.counter > 0 and not forloop.last %}
                 </div>
-                {% if forloop.counter|divisibleby:5 and forloop.counter > 0 and not forloop.last %}
-            </div>
-            <div class="carousel-item ">
-                {% endif %} {% endfor %}
+                <div class="carousel-item">
+                    {% endif %} {% endfor %}
+                </div>
             </div>
         </div>
         <a class="carousel-control-prev top-books-carousel" href="#demo" role="button" data-slide="prev">


### PR DESCRIPTION
## Description
- Changed the layout of the explore page to make it user friendly. Made it similar to the layout of the book-genre page.
- made changes in the files explore.html and explore.css
- closes #74 

Before:
![image](https://user-images.githubusercontent.com/59871941/111675915-aa859680-8843-11eb-87ff-3056e2349295.png)


After:
![image](https://user-images.githubusercontent.com/59871941/111675941-b2ddd180-8843-11eb-9410-88ac61c6a81d.png)


on small screens:
![explorePagePhone](https://user-images.githubusercontent.com/59871941/111676321-0d772d80-8844-11eb-9e67-3171b9fa69ad.gif)



## Affected Dependencies


## How has this been tested?
Ran it in my localhost

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/Praful932/Kitabe/blob/master/CONTRIBUTING.md).
- [x] My changes do not edit/add any unrequired files.
- [x] My changes are covered by tests.

