### PR TITLE
Fix No. of characters shown in Book Cards

### DIFF
--- a/BookRecSystem/settings.py
+++ b/BookRecSystem/settings.py
@@ -22,13 +22,12 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-# SECRET_KEY = os.environ.get('KITABE_SECRET_KEY')
-SECRET_KEY = "RANDOM_KEY"
+SECRET_KEY = os.environ.get('KITABE_SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['kitabe-app.herokuapp.com', '127.0.0.1', 'localhost']
+ALLOWED_HOSTS = ['kitabe-app.herokuapp.com']
 
 
 # Application definition

--- a/templates/mainapp/explore.html
+++ b/templates/mainapp/explore.html
@@ -21,8 +21,8 @@ Explore
                 <img class=" card-img  mt-4 " src="{{book.image_url}}" alt="book Card">
                 
                 <div class="content text-center">
-                    <div class="card-title">{{ book.original_title }}</div>
-                    <div class="card-text">by {{ book.authors}}</div>
+                    <div class="card-title">{{ book.original_title|truncatechars:30 }}</div>
+                    <div class="card-text">by {{ book.authors|truncatechars:25}}</div>
                 </div>
             </div><br>
             <a href="javascript:;" onclick='bookDetails(this)' class="btn more-details"
@@ -65,8 +65,8 @@ Explore
                             <img class=" cover-img-size" src="{{book.image_url}}" alt="book Card">
                             
                             <div class="card-body text-center">
-                                <div class="card-title">{{ book.original_title }}</div>
-                                <div class="card-text">by {{ book.authors}}</div>
+                                <div class="card-title">{{ book.original_title|truncatechars:30 }}</div>
+                                <div class="card-text">by {{ book.authors|truncatechars:30}}</div>
                             </div>
                         </div><br>
                         <a href="javascript:;" onclick='bookDetails(this)' class="btn more-details"
@@ -118,8 +118,8 @@ Explore
                             <img class=" cover-img-size" src="{{book.image_url}}" alt="book Card">
                             
                             <div class="card-body text-center">
-                                <div class="card-title">{{ book.original_title }}</div>
-                                <div class="card-text">by {{ book.authors}}</div>
+                                <div class="card-title">{{ book.original_title|truncatechars:30 }}</div>
+                                <div class="card-text">by {{ book.authors|truncatechars:30}}</div>
                             </div>
                         </div><br>
                         <a href="javascript:;" onclick='bookDetails(this)' class="btn more-details"
@@ -170,8 +170,8 @@ Explore
                             <img class=" cover-img-size" src="{{book.image_url}}" alt="book Card">
                             
                             <div class="card-body text-center">
-                                <div class="card-title">{{ book.original_title }}</div>
-                                <div class="card-text">by {{ book.authors}}</div>
+                                <div class="card-title">{{ book.original_title |truncatechars:30}}</div>
+                                <div class="card-text">by {{ book.authors|truncatechars:30}}</div>
                             </div>
                         </div><br>
                         <a href="javascript:;" onclick='bookDetails(this)' class="btn more-details"

--- a/templates/mainapp/genre.html
+++ b/templates/mainapp/genre.html
@@ -22,8 +22,8 @@ Genre
         <div class="row no-gutters">
             <img class="card-img  mt-4 " src="{{book.image_url}}" alt="book Card">
             <div class="card-body text-center">
-                <h5 class="card-title">{{book.original_title}}</h5>
-                <p class="card-text"><i>by {{book.authors}}</i></p>
+                <h5 class="card-title">{{book.original_title|truncatechars:35}}</h5>
+                <p class="card-text"><i>by {{book.authors|truncatechars:25}}</i></p>
             </div>
         </div><br>
         <a href="javascript:;" onclick='bookDetails(this)' class="btn more-details"


### PR DESCRIPTION
## Description
- Reduced the amount of text to be displayed on each book tile
- #148 

## Affected Dependencies
N/A

## How has this been tested?
Using flake8, python manage.py test.
No test fails.

## GIF Before
![screentogif_before](https://user-images.githubusercontent.com/52230497/112826310-72375100-90aa-11eb-8f93-258d33462016.gif)


## GIF After
![screentogif_after](https://user-images.githubusercontent.com/52230497/112826330-782d3200-90aa-11eb-9243-7c1c67996ab1.gif)


## Checklist
- [✓ ] I have followed the [Contribution Guidelines](https://github.com/Praful932/Kitabe/blob/master/CONTRIBUTING.md).
- [✓ ] My changes do not edit/add any unrequired files.
- [✓ ] My changes are covered by tests.

