### PR TITLE
Changed font of authors name across all the templates

### DIFF
--- a/static/mainapp/css/explore.css
+++ b/static/mainapp/css/explore.css
@@ -37,7 +37,7 @@
 }
 
 .author {
-  font-family: "Courgette", cursive;
+  font-family: "Rockwell", serif;
   font-weight: bold;
 }
 
@@ -166,7 +166,7 @@
 }
 
 .card-text {
-  font-family: "Courgette", cursive;
+  font-family: "Rockwell", serif;
   color: black;
   font-weight: bold;
   font-size: 15px;

--- a/static/mainapp/css/genre.css
+++ b/static/mainapp/css/genre.css
@@ -46,7 +46,7 @@
 }
 
 .card-text {
-  font-family: "Courgette", cursive;
+  font-family: "Rockwell", serif;
   color: black;
   font-weight: bold;
   font-size: 15px;

--- a/static/mainapp/css/index.css
+++ b/static/mainapp/css/index.css
@@ -249,7 +249,7 @@ ol.carousel-indicators li.active {
 }
 
 .card-text {
-  font-family: "Courgette", cursive;
+  font-family: "Rockwell", serif;
   color: black;
   font-weight: bold;
   font-size: large;

--- a/static/mainapp/css/read.css
+++ b/static/mainapp/css/read.css
@@ -36,7 +36,7 @@
   }
 
   .card-text {
-    font-family: "Courgette", cursive;
+    font-family: "Rockwell", serif;
     color: black;
     font-weight: bold;
     font-size: 1.25rem;

--- a/templates/mainapp/genre.html
+++ b/templates/mainapp/genre.html
@@ -3,7 +3,7 @@
 
 {% block title  %}
 Genre
-{% endblock title %}
+{% endblock title %} 
 
 {% block head %}
 <link rel="stylesheet" href="{% static 'mainapp/css/genre.css' %}">
@@ -12,7 +12,7 @@ Genre
 
 {% block main %}
 
-<h1 class="genre-head text-center pt-3 pb-3">{{ genre }} Genre</h1>
+<h1 class="genre-head text-center pt-3 pb-3">{{ genre }}</h1>
 
 
 <div class="card-deck ">


### PR DESCRIPTION
## Description
- Changed font of authors name across all the templates
- Removed 'Genre' from the heading of the genre template.


## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/Praful932/Kitabe/blob/master/CONTRIBUTING.md).
- [x] My changes do not edit/add any unrequired files.
- [x] My changes are covered by tests.

