### PR TITLE
Align Popular Among Us Book Cards

### DIFF
--- a/static/mainapp/css/index.css
+++ b/static/mainapp/css/index.css
@@ -118,7 +118,7 @@
 
 .carousel img {
   width: 100%;
-  height: auto;
+  height: 160px;
 }
 
 .genre-head,

--- a/static/mainapp/css/index.css
+++ b/static/mainapp/css/index.css
@@ -118,6 +118,9 @@
 
 .carousel img {
   width: 100%;
+  height: auto;
+}
+#demo img {
   height: 160px;
 }
 
@@ -330,12 +333,18 @@ ol.carousel-indicators li.active {
   .col-md-3point9 {
     max-width: 33%;
   }
+  #demo .card-title {
+    margin-top: 0rem;
+  }
 }
 /* media query*/
 
 @media screen and (max-width: 575px){
   .col-lg-3:hover{
     transform: scale(1.03);
+  }
+  #demo .card-title {
+    margin-top: 2rem;
   }
 }
 
@@ -361,7 +370,6 @@ ol.carousel-indicators li.active {
   }
   .card-title {
     font-size: 18px;
-    margin-top: 2.5rem;
   }
   .rating-block {
     padding-top: 1px;
@@ -376,5 +384,12 @@ ol.carousel-indicators li.active {
     align-items: center;
     margin-left: -9%;
     margin-right: -9%;
+  }
+}
+
+@media screen and (min-width: 600px) {
+  #demo .card-title{
+    margin-top: 0rem;
+    margin-bottom: 0rem;
   }
 }

--- a/static/mainapp/css/index.css
+++ b/static/mainapp/css/index.css
@@ -357,10 +357,11 @@ ol.carousel-indicators li.active {
   }
   .card-body {
     margin-top: -220px;
-    margin-left: 115px;
+    margin-left: 130px;
   }
   .card-title {
     font-size: 18px;
+    margin-top: 2.5rem;
   }
   .rating-block {
     padding-top: 1px;

--- a/templates/mainapp/index.html
+++ b/templates/mainapp/index.html
@@ -321,8 +321,8 @@
                             </div>
                             <div class="col-sm-8">
                                 <div class="card-body">
-                                    <div class="card-title">{{book.original_title|truncatechars:60 }}</div>
-                                    <p class="card-text"><i>by {{book.authors|truncatechars:20}}</i></p>
+                                    <div class="card-title">{{book.original_title|truncatechars:30 }}</div>
+                                    <p class="card-text"><i>by {{book.authors|truncatechars:15}}</i></p>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## Description
- Fixing the height of the carousel to make it uniform
- Fixes #229 

## Affected Dependencies
NA

## How has this been tested?
`python manage.py test`


## GIF Before
![book_card_before](https://user-images.githubusercontent.com/52230497/118135619-dfb3fc80-b420-11eb-8df6-c4851bf36197.gif)

## GIF After
![book_card_after](https://user-images.githubusercontent.com/52230497/118135650-e6427400-b420-11eb-9687-5206d210cec9.gif)


## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/Praful932/Kitabe/blob/master/CONTRIBUTING.md).
- [X] My changes do not edit/add any unrequired files.
- [X] My changes are covered by tests.

