### PR TITLE
Fix for button size on Explore page

### DIFF
--- a/static/mainapp/css/explore.css
+++ b/static/mainapp/css/explore.css
@@ -155,9 +155,11 @@
   font-size: 11px;
   border-radius: 20px;
   position: absolute;
-  padding: 8px;
   bottom: 10px;
-  left: 7%;
+  left: 4%;
+}
+.rating-block.btn,.btn.more-details{
+  padding: 8px;
 }
 
 .rating-block:hover {


### PR DESCRIPTION
## Description
- Changed the padding of buttons
- Fixes #235 
## Affected Dependencies


## How has this been tested?
`flake8, python manage.py test`

## GIF Before
![before-button](https://user-images.githubusercontent.com/52230497/118777660-ef12ca00-b8a6-11eb-9569-3d46ed6e67a0.gif)

## GIF After
![after-button](https://user-images.githubusercontent.com/52230497/118777736-02be3080-b8a7-11eb-85fa-9e70ed6fb88e.gif)


## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/Praful932/Kitabe/blob/master/CONTRIBUTING.md).
- [X] My changes do not edit/add any unrequired files.
- [X] My changes are covered by tests.

